### PR TITLE
Update ML_2016_BE_euscilc_cs.do

### DIFF
--- a/ML_2016_BE_eusilc_cs.do
+++ b/ML_2016_BE_eusilc_cs.do
@@ -25,7 +25,7 @@ replace ml_eli = 0 		if ml_eli == . & country == "BE" & year == 2016 & gender ==
 		-> total: 15 weeks
 		-> prenatal: 1 (compulsory)
 	-> self-employed: 
-		-> total: 12 weeks
+		-> total: 8 weeks
 */
 
 replace ml_dur1 = 1 	if country == "BE" & year == 2016 & gender == 1 ///
@@ -37,7 +37,7 @@ replace ml_dur1 = 1 	if country == "BE" & year == 2016 & gender == 1 ///
 replace ml_dur2 = 15-1 	if country == "BE" & year == 2016 & gender == 1 ///
 						& ml_eli == 1
 			
-replace ml_dur2 = 12-1 	if country == "BE" & year == 2016 & gender == 1 ///
+replace ml_dur2 = 8-1 	if country == "BE" & year == 2016 & gender == 1 ///
 						& econ_status == 2 & ml_eli == 1
 
 
@@ -46,13 +46,13 @@ replace ml_dur2 = 12-1 	if country == "BE" & year == 2016 & gender == 1 ///
 * BENEFIT (monthly)
 /* 	-> employed (MISSOC 01/07/2016): 
 		-> first 30 days = 82% earnings, no ceiling 
-		-> rest of leave = 75% earnings, ceiling €104.8/day.			
+		-> rest of leave = 75% earnings, ceiling €133.00/day.			
 	-> unemployed (M2016): 
-		-> first month = unemployment benefit + 19% of previous earnings with a ceiling €111.09/day
-		-> rest = unemployment benefit + 15% with a ceiling €104.8/day
+		-> first month = unemployment benefit + 19% of previous earnings with a ceiling €133.0/day
+		-> rest = unemployment benefit + 15% with a ceiling €133.0/day
 		-> not coded (EU-SILC unemployment benefit - household level data)
 	-> self-employed (LP&R 2016):
-		-> €458/week
+		-> €440.5/week
 */
 
 gen ceiling = (0.75*earning) 		// for the purpose of ceiling calculation
@@ -61,20 +61,20 @@ gen ceiling = (0.75*earning) 		// for the purpose of ceiling calculation
 replace ml_ben1 = (((((0.82*earning) / 4.3) * (30/5)) + (((0.75*earning)/4.3) * (15 - (30/5)))) / 15) * 4.3 /// 
 						if country == "BE" & year == 2016 & gender == 1 ///
 						& econ_status == 1 & ml_ben1 == . & ml_eli == 1 ///
-						& ceiling <= 104.8*21.7
+						& ceiling <= 133.0*21.7
 
 
 						
 * above ceiling						
-replace ml_ben1 = (((((0.82*earning) / 4.3) * (30/5)) + (((104.8 * 5) * (15 - (30/5))))) / 15) * 4.3 ///
+replace ml_ben1 = (((((0.82*earning) / 4.3) * (30/5)) + (((133.0 * 5) * (15 - (30/5))))) / 15) * 4.3 ///
 						if country == "BE" & year == 2016 & gender == 1 ///
 						& econ_status == 1 & ml_ben1 == . & ml_eli == 1 ///
-						& ceiling > 104.8*21.7
+						& ceiling > 133.0*21.7
 				
 
 	
 * self-employed
-replace ml_ben1 = 458 * 4.3 		if country == "BE" & year == 2016 ///
+replace ml_ben1 = 440.5 * 4.3 		if country == "BE" & year == 2016 ///
 									& gender == 1 & econ_status == 2 ///
 									& ml_ben1 == . & ml_eli == 1
 
@@ -85,7 +85,7 @@ replace ml_ben2 = 0.82 * earning ///
 						& econ_status == 1 & ml_ben2 == . & ml_eli == 1
 			
 
-replace ml_ben2 = 458*4.3 ///
+replace ml_ben2 = 440.5*4.3 ///
 						if country == "BE" & year == 2016 & gender == 1 ///
 						& econ_status == 2 & ml_ben2 == . & ml_eli == 1
 


### PR DESCRIPTION
Changes that were made:
- From 12 weeks (2018) to 8 weeks (2016) for self-employed
- From 104.8 ceiling (2018) to 133.0 ceiling (2016) for employed/unemployed 
- From 458 per week (2018) to 440.5 per week (2016) for self-employed