### PR TITLE
Update ML_2016_GB_eusilc_cs.do

### DIFF
--- a/ML_2016_GB_eusilc_cs.do
+++ b/ML_2016_GB_eusilc_cs.do
@@ -6,7 +6,7 @@
 * ELIGIBILITY
 /*	-> employed (statutory maternity pay), self-employed (maternity allowance): 
 		- for 26 weeks before childbirth 
-		- earning at least €34/week
+		- earning at least €36/week
 	-> further restrictions for entitlement to cash benefits
 	
 	-> part of ML can be shared with the father (shared parental leave) if:
@@ -20,7 +20,7 @@
 */
 
 replace ml_eli = 1 			if country == "GB" & year == 2016 & gender == 1 ///
-							& inlist(econ_status,1,2) & (earning/4.3) >= 34 ///
+							& inlist(econ_status,1,2) & (earning/4.3) >= 36 ///
 							& (duremp+dursemp) >= 26/4.3
 
 * father's eligibility for shared parental leave 
@@ -35,12 +35,12 @@ replace ml_eli = 0 			if ml_eli == . & country == "GB" & year == 2016 & gender =
 /*	-> employed if (for paid leave):
 		- employed by the same employer (not coded)
 		- for 26 weeks 
-		- average weekly earnings at least €131
+		- average weekly earnings at least €136
 		- duration: 52 weeks  
 		
 	-> self-employed and employed if
 		- working for at least 26 weeks (coded) in the 66 weeks before birth (not coded)
-		- average weekly earnings at least €34
+		- average weekly earnings at least €39
 		- duration: 39 weeks
 		
 	-> no compulsory prenatal leave (can take up to 11 weeks)
@@ -54,11 +54,11 @@ replace ml_dur1 = 0 		if country == "GB" & year == 2016 & ml_eli == 1 & gender =
 
 replace ml_dur2 = 52 		if country == "GB" & year == 2016 & ml_eli == 1 ///
 							& econ_status == 1 & duremp >= 26/4.3 ///
-							& (earning/4.3) >= 131 & gender == 1
+							& (earning/4.3) >= 136 & gender == 1
 							
 replace ml_dur2 = 39		if country == "GB" & year == 2016 & ml_eli == 1 ///
 							& inlist(econ_status,1,2) & ml_dur2 == . ///
-							& (earning/4.3) >= 34 & gender == 1
+							& (earning/4.3) >= 39 & gender == 1
 
 
 
@@ -66,40 +66,40 @@ replace ml_dur2 = 39		if country == "GB" & year == 2016 & ml_eli == 1 ///
 /*	->  employed women who fulfil the stricter conditions (see "Duration"):
 			- 6 weeks: 90% earnings (taxed)
 			- 33 weeks: 90% earnings (taxed)
-				- ceiling: €164/week 
+				- ceiling: €181/week 
 			- 13 weeks: unpaid
 			
 	-> employed and self-employed (maternity allowance):
 			-39 weeks: 90% earning (not taxed)
-				- ceiling: €164/week 
+				- ceiling: €181/week 
 */
 
 
 * statutory maternity pay
 gen ml_bena = 0.9 * earning			if country == "GB" & year == 2016 & ml_eli == 1
-gen ml_benb = (164 * 4.3)			if country == "GB" & year == 2016 & ml_eli == 1 
+gen ml_benb = (181 * 4.3)			if country == "GB" & year == 2016 & ml_eli == 1 
 
 									
 	* under ceiling
 replace ml_ben1 = (ml_bena * (39/52))		if country == "GB" & year == 2016 & ml_eli == 1 ///
-											& (earning*0.9)/4.3 < 164 & ml_dur2 == 52
+											& (earning*0.9)/4.3 < 181 & ml_dur2 == 52
 
 	* above ceiling
 replace ml_ben1 = (ml_bena * (6/52)) + (ml_benb * ((39-6)/52))		///
 											if country == "GB" & year == 2016 & ml_eli == 1 ///
-											& (earning*0.9)/4.3 >= 164 & ml_dur2 == 52
+											& (earning*0.9)/4.3 >= 181 & ml_dur2 == 52
 
 
 
 * maternity allowance	
 	* under ceiling
 replace ml_ben1 = ml_bena		if country == "GB" & year == 2016 & ml_eli == 1 ///
-								& (earning*0.9)/4.3 < 164 & ml_dur2 == 39	
+								& (earning*0.9)/4.3 < 181 & ml_dur2 == 39	
 	
 	
 	* above ceiling
 replace ml_ben1 = ml_benb		if country == "GB" & year == 2016 & ml_eli == 1 ///
-								& (earning*0.9)/4.3 >= 164 & ml_dur2 == 39
+								& (earning*0.9)/4.3 >= 181 & ml_dur2 == 39
 	
 	
 	


### PR DESCRIPTION
Changes made:
- Employed (statutory maternity pay), self-employed (maternity allowance) earnings from €34/week (2018) to €36/week (2016)
- Average weekly earnings for employed at least €131 (2018) to €136 (2016)
- Average weekly earnings for self-employed at least €34 (2018) to €39 (2016)
- Benefit ceiling: from - ceiling: €164.8/week (2018) to 181/week (2016)

- Could not find the euro value for "Father/partner value has changed from earned at least €441." The GBP in LP&R for 2016 is £390