### PR TITLE
Update ML_2015_AT_eusilc_cs.do

### DIFF
--- a/ML_2015_AT_eusilc_cs.do
+++ b/ML_2015_AT_eusilc_cs.do
@@ -3,7 +3,7 @@
 * AUSTRIA - 2016
 
 * ELIGIBILITY
-/* -> Employed: earnings at least €415.72/month  
+/*   
    -> Self-employed: if voluntarily insured => not coded.
    -> Unemployed: if receive unemployment benefits/completed 3 months of 
 	continuous  employment		
@@ -12,7 +12,7 @@
 */
    
 replace ml_eli = 1 		if country == "AT" & year == 2016 & gender == 1 ///
-						& econ_status == 1 & earning >= 415.72
+						& econ_status == 1 
 replace ml_eli = 1 		if country == "AT" & year == 2016 & gender == 1 ///
 						& econ_status == 3 & duremp >= 3
 				
@@ -31,8 +31,8 @@ replace ml_dur2 = 8 	if country == "AT" & year == 2016 & gender == 1 & ml_eli ==
 
 * BENEFIT (monthly)
 /*	-> 100% earnings, no ceiling
-	-> marginally employed, self-insured: €8.91/day (not coded) 
-	-> self-employed: €52.96/day	(not coded; LP&R 2016)		
+	-> marginally employed, self-insured: €8.80/day (not coded) 
+	-> self-employed: €52.07/day	(not coded; LP&R 2016)		
 	-> unemployed: 180% of unemployment benefits (not coded)
 */
 	


### PR DESCRIPTION
Changes made:
- Deleted "Employed: earnings at least €415.72/month" in ml_eli 
- Benefit values for self-insured and self-employed