### PR TITLE
Update PT_2015_RO_eusilc_cs.do

### DIFF
--- a/PT_2015_RO_eusilc_cs.do
+++ b/PT_2015_RO_eusilc_cs.do
@@ -14,7 +14,9 @@ replace pt_eli = 0 		if pt_eli == . & country == "RO" & year == 2015 & gender ==
 
 
 * DURATION (weeks)
-/*	*/
+/*	-> 5 days
+	-> can be extended of 5 days if father attends a course in childcare (not coded)
+*/
 	
 replace pt_dur = 5/5 	if country == "RO" & year == 2015 & pt_eli == 1
 

--- a/PT_2015_RO_eusilc_cs.do
+++ b/PT_2015_RO_eusilc_cs.do
@@ -14,8 +14,7 @@ replace pt_eli = 0 		if pt_eli == . & country == "RO" & year == 2015 & gender ==
 
 
 * DURATION (weeks)
-/*	-> 5 days
-	-> can be extended of 5 days if father attends a course in childcare (not coded)	*/
+/*	*/
 	
 replace pt_dur = 5/5 	if country == "RO" & year == 2015 & pt_eli == 1
 


### PR DESCRIPTION
I didn't change anything, but there isn't a single word about paternity leave in the MISSOC tables, and Romania wasn't in the report of leavenetwork before 2016, so nothing at all there either. Same for parental leave, also no info at all.