### PR TITLE
Update ML_2015_RO_eusilc_cs.do

### DIFF
--- a/ML_2015_RO_eusilc_cs.do
+++ b/ML_2015_RO_eusilc_cs.do
@@ -33,16 +33,11 @@ replace ml_dur2 = (63+63)-(6*5)/5	if country == "RO" & year == 2015 & ml_eli == 
 
 
 * BENEFIT (monthly)
-/*	-> 85% of average gross earnings 
-	-> ceiling: 85% of 12x the minimum gross wage (according to LP&R 2015 - no ceiling)
-		-> minimum wage (Eurostat): €407.45
+/*	-> 85% of average gross earnings
 	-> it is unclear how are benefits calculated for unemployed women 
 		and w. with no income => not coded */
 
 replace ml_ben1 = 0.85*earning 		if country == "RO" & year == 2015 & ml_eli == 1
-
-replace ml_ben1 = 0.85*(12*407.45)	if country == "RO" & year == 2015 & ml_eli == 1 ///
-									& ml_ben1 > 0.85*(12*407.45)
 
 
 replace ml_ben2 = ml_ben1 			if country == "RO" & year == 2015 & ml_eli == 1


### PR DESCRIPTION
Nothing about ceilings or minimum wages on MISSOC. As for the reports of leavenetwork: same story for parental leave and paternity leave: Romania wasn't in the reports of 2015 and before