### PR TITLE
Update ML_2015_SE_eusilc_cs.do

### DIFF
--- a/ML_2015_SE_eusilc_cs.do
+++ b/ML_2015_SE_eusilc_cs.do
@@ -37,7 +37,7 @@ replace ml_dur2 = 60/7 		if country == "SE" & year == 2015 & ml_eli == 1
 /*	-> eligible for earning related benefit: min. income €24/day (coded) for 240 calendar days (not coded) before childbirth
 		- for 195 calendar days (includes 90 non-transferable leave): 77.6% earning
 			- minimum: €24/day
-			- ceiling: €48,136/month - this is an earning ceiling NOT benefit ceiling (LP&R 2015)
+			- ceiling: €48,136/year - this is an earning ceiling NOT benefit ceiling (LP&R 2015)
 		- for 45 days: €19/day (only applicable for pl_ben)
 	-> all others: €24/day
  */
@@ -47,8 +47,8 @@ replace ml_ben1 = 0.776*earning 		if country == "SE" & year == 2015 & ml_eli == 
 										& (earning/30) >= 23 /*  Shouldn't it be 24 here? if someone makes 23,80/day for instance, they should get the minimum of 24 instead right?  */
 replace ml_ben1 = 24*30					if country == "SE" & year == 2015 & ml_eli == 1 ///
 										& ml_ben1 < 24*30
-replace ml_ben1 = 0.776*48136			if country == "SE" & year == 2015 & ml_eli == 1 ///
-										& earning >= 48136
+replace ml_ben1 = 0.776*(48136/12)			if country == "SE" & year == 2015 & ml_eli == 1 ///
+										& earning >= (48136/12)
 
 									
 replace ml_ben2 = ml_ben1 			if country == "SE" & year == 2015 & ml_eli == 1

--- a/ML_2015_SE_eusilc_cs.do
+++ b/ML_2015_SE_eusilc_cs.do
@@ -23,32 +23,32 @@ replace ml_eli = 0 			if ml_eli == . & country == "SE" & year == 2015 & gender =
 
 
 * DURATION (weeks)
-/*	-> total: 90 calendar days 
+/*	-> total: 60 calendar days 
 	-> prenatal: non-compulsory 2 weeks 	
 	-> single fathers: entitled to the whole share 	
 */
 
 replace ml_dur1 = 0 		if country == "SE" & year == 2015 & ml_eli == 1
 
-replace ml_dur2 = 90/7 		if country == "SE" & year == 2015 & ml_eli == 1
+replace ml_dur2 = 60/7 		if country == "SE" & year == 2015 & ml_eli == 1
 
 
 * BENEFIT (monthly)
-/*	-> eligible for earning related benefit: min. income €27/day (coded) for 240 calendar days (not coded) before childbirth
+/*	-> eligible for earning related benefit: min. income €24/day (coded) for 240 calendar days (not coded) before childbirth
 		- for 195 calendar days (includes 90 non-transferable leave): 77.6% earning
-			- minimum: €27/day
-			- ceiling: €46,972/month - this is an earning ceiling NOT benefit ceiling (LP&R 2015)
+			- minimum: €24/day
+			- ceiling: €48,136/month - this is an earning ceiling NOT benefit ceiling (LP&R 2015)
 		- for 45 days: €19/day (only applicable for pl_ben)
-	-> all others: €27/day
+	-> all others: €24/day
  */
 
  
 replace ml_ben1 = 0.776*earning 		if country == "SE" & year == 2015 & ml_eli == 1 ///
-										& (earning/30) >= 26
-replace ml_ben1 = 27*30					if country == "SE" & year == 2015 & ml_eli == 1 ///
-										& ml_ben1 < 27*30
-replace ml_ben1 = 0.776*46972			if country == "SE" & year == 2015 & ml_eli == 1 ///
-										& earning >= 46972
+										& (earning/30) >= 23 /*  Shouldn't it be 24 here? if someone makes 23,80/day for instance, they should get the minimum of 24 instead right?  */
+replace ml_ben1 = 24*30					if country == "SE" & year == 2015 & ml_eli == 1 ///
+										& ml_ben1 < 24*30
+replace ml_ben1 = 0.776*48136			if country == "SE" & year == 2015 & ml_eli == 1 ///
+										& earning >= 48136
 
 									
 replace ml_ben2 = ml_ben1 			if country == "SE" & year == 2015 & ml_eli == 1


### PR DESCRIPTION
I updated the numbers here, but see my note on the '>= 23' part in the code itself. You wrote >= 26 when the minimum was 27, so I changed this to >= 23 when the minimum is 24, although I think it should be 24. This is also aplicable to paternity and parental leave.