### PR TITLE
Update ML_2014_IE_eusilc_cs.do

### DIFF
--- a/ML_2014_IE_eusilc_cs.do
+++ b/ML_2014_IE_eusilc_cs.do
@@ -31,7 +31,8 @@ replace ml_dur2 = 26+16-2 		if country == "IE" & year == 2014 & ml_eli == 1
 
 
 * BENEFIT (monthly)
-/*	-> 26 weeks: €230/week
+/*	-> 26 weeks: "80% of average weekly earnings (subject to a ceiling) in the relevant tax year."
+	-> ceiling: €230/week
 	-> 16 weeks: unpaid 	*/
 	
 replace ml_ben1 = ((230*4.3) * (26/(26+16)))  	if country == "IE" & year == 2014 & ml_eli == 1


### PR DESCRIPTION
In the MISSOC tables there is this "80% of average weekly earnings", which is replaced by the flat rate of €230/week from 2015 and later. There isn't anything about this on leavenetwork however. I wasn't sure how to code this in the code section so I left it open.