### PR TITLE
Update PL_2017_NO_eusilc_cs.do

### DIFF
--- a/PL_2017_NO_eusilc_cs.do
+++ b/PL_2017_NO_eusilc_cs.do
@@ -40,23 +40,23 @@ replace pl_dur = 19 		if country == "NO" & year == 2018 & pl_eli == 1 & gender =
 
 * BENEFIT (monthly)
 /*	-> 100% earning
-	-> ceiling: €9,735/month 
-	-> minimum: maternity grant - €6,665 for the whole period (11 months)
+	-> ceiling: €68,542/year
+	-> minimum: maternity grant - €8,862 for the whole period (11 months)
 */
 
 	* women
 replace pl_ben1 = earning 		if country == "NO" & year == 2018 & pl_eli == 1 & gender ==1
-replace pl_ben1 = 9735		if country == "NO" & year == 2018 & pl_eli == 1 ///
-								& pl_ben1 >= 9735 & gender == 1
-replace pl_ben1 = 6665/11		if country == "NO" & year == 2018 & pl_eli == 1 ///
-								& pl_ben1 < 6665/11 & gender == 1
+replace pl_ben1 = 68542/12		if country == "NO" & year == 2018 & pl_eli == 1 ///
+								& pl_ben1 >= (68542/12) & gender == 1
+replace pl_ben1 = 8862/11		if country == "NO" & year == 2018 & pl_eli == 1 ///
+								& pl_ben1 < 8862/11 & gender == 1
 
 	* single men
 replace pl_ben1 = earning 		if country == "NO" & year == 2018 & pl_eli == 1 & gender == 2 & parstat == 1
-replace pl_ben1 = 9735		if country == "NO" & year == 2018 & pl_eli == 1 ///
-								& pl_ben1 >= 9,735 & gender == 2 & parstat == 1
-replace pl_ben1 = 6665/11		if country == "NO" & year == 2018 & pl_eli == 1 ///
-								& pl_ben1 < 6665/11 & gender == 2 & parstat == 1
+replace pl_ben1 = 68542/12		if country == "NO" & year == 2018 & pl_eli == 1 ///
+								& pl_ben1 >= (68542/12) & gender == 2 & parstat == 1
+replace pl_ben1 = 8862/11		if country == "NO" & year == 2018 & pl_eli == 1 ///
+								& pl_ben1 < 8862/11 & gender == 2 & parstat == 1
 
 
 replace pl_ben2 = pl_ben1		if country == "NO" & year == 2018 & pl_eli == 1

--- a/PL_2017_NO_eusilc_cs.do
+++ b/PL_2017_NO_eusilc_cs.do
@@ -40,21 +40,21 @@ replace pl_dur = 19 		if country == "NO" & year == 2018 & pl_eli == 1 & gender =
 
 * BENEFIT (monthly)
 /*	-> 100% earning
-	-> ceiling: €61,357/year  
+	-> ceiling: €9,735/month 
 	-> minimum: maternity grant - €6,665 for the whole period (11 months)
 */
 
 	* women
 replace pl_ben1 = earning 		if country == "NO" & year == 2018 & pl_eli == 1 & gender ==1
-replace pl_ben1 = 61357/12		if country == "NO" & year == 2018 & pl_eli == 1 ///
-								& pl_ben1 >= 61357/12 & gender == 1
+replace pl_ben1 = 9735		if country == "NO" & year == 2018 & pl_eli == 1 ///
+								& pl_ben1 >= 9735 & gender == 1
 replace pl_ben1 = 6665/11		if country == "NO" & year == 2018 & pl_eli == 1 ///
 								& pl_ben1 < 6665/11 & gender == 1
 
 	* single men
 replace pl_ben1 = earning 		if country == "NO" & year == 2018 & pl_eli == 1 & gender == 2 & parstat == 1
-replace pl_ben1 = 61357/12		if country == "NO" & year == 2018 & pl_eli == 1 ///
-								& pl_ben1 >= 61357/12 & gender == 2 & parstat == 1
+replace pl_ben1 = 9735		if country == "NO" & year == 2018 & pl_eli == 1 ///
+								& pl_ben1 >= 9,735 & gender == 2 & parstat == 1
 replace pl_ben1 = 6665/11		if country == "NO" & year == 2018 & pl_eli == 1 ///
 								& pl_ben1 < 6665/11 & gender == 2 & parstat == 1
 


### PR DESCRIPTION
I double checked and it is actually that high: a ceiling of €9735/month.
I also double checked the flat-rate payment for non-employed women, and I can't believe the info in LP&R 2017. It says: "As of 1 January 2017, non-employed women receive a flat-rate payment of NOK61,120[€6,427] per child per month." --> €6427 per month sounds absurdly high, so i didn't code it... I think it must be an error of LP&R.
If you look at one year before it says: "Non-employed women receive a flat-rate payment of NOK46,000 [€4,951]." --> for the whole period I suppose.
If you look at one year after it says: "As of 1 January 2018, non-employed women receive a flat-rate payment of NOK63,140 [€6,696.95] per child." --> for the whole period I suppose.