### PR TITLE
Update ML_2012_BE_eusilc_cs.do

### DIFF
--- a/ML_2012_BE_eusilc_cs.do
+++ b/ML_2012_BE_eusilc_cs.do
@@ -46,14 +46,10 @@ replace ml_dur2 = 8-1 	if country == "BE" & year == 2012 & gender == 1 ///
 * BENEFIT (monthly)
 /* 	-> employed (MISSOC 01/07/2012): 
 		-> first 30 days = 82% earnings, no ceiling 
-		-> rest of leave = 75% earnings, ceiling €133.00/day.			
-	-> unemployed (M2012): 
-		-> first month = unemployment benefit + 19% of previous earnings with a ceiling €133.0/day
-		-> rest = unemployment benefit + 15% with a ceiling €133.0/day
-		-> not coded (EU-SILC unemployment benefit - household level data)
-	-> self-employed (LP&R 2012):
-		-> €440.5/week
+		-> rest of leave = 75% earnings, ceiling €94.87/day.	
+		
 */
+
 
 gen ceiling = (0.75*earning) 		// for the purpose of ceiling calculation
 
@@ -61,22 +57,17 @@ gen ceiling = (0.75*earning) 		// for the purpose of ceiling calculation
 replace ml_ben1 = (((((0.82*earning) / 4.3) * (30/5)) + (((0.75*earning)/4.3) * (15 - (30/5)))) / 15) * 4.3 /// 
 						if country == "BE" & year == 2012 & gender == 1 ///
 						& econ_status == 1 & ml_ben1 == . & ml_eli == 1 ///
-						& ceiling <= 133.0*21.7
+						& ceiling <= 94.87*21.7
 
 
 						
 * above ceiling						
-replace ml_ben1 = (((((0.82*earning) / 4.3) * (30/5)) + (((133.0 * 5) * (15 - (30/5))))) / 15) * 4.3 ///
+replace ml_ben1 = (((((0.82*earning) / 4.3) * (30/5)) + (((94.87 * 5) * (15 - (30/5))))) / 15) * 4.3 ///
 						if country == "BE" & year == 2012 & gender == 1 ///
 						& econ_status == 1 & ml_ben1 == . & ml_eli == 1 ///
-						& ceiling > 133.0*21.7
+						& ceiling > 94.87*21.7
 				
 
-	
-* self-employed
-replace ml_ben1 = 440.5 * 4.3 		if country == "BE" & year == 2012 ///
-									& gender == 1 & econ_status == 2 ///
-									& ml_ben1 == . & ml_eli == 1
 
 
 * ML benefit in the first month
@@ -84,10 +75,6 @@ replace ml_ben2 = 0.82 * earning ///
 						if country == "BE" & year == 2012 & gender == 1 ///
 						& econ_status == 1 & ml_ben2 == . & ml_eli == 1
 			
-
-replace ml_ben2 = 440.5*4.3 ///
-						if country == "BE" & year == 2012 & gender == 1 ///
-						& econ_status == 2 & ml_ben2 == . & ml_eli == 1
 
 
 


### PR DESCRIPTION
Removed unemployed and self-employed.
MISSOC says that "special regulations for unemployed workers and for disabled for benefits for unemployed" but does not provide any amounts. I was also unable to find the amounts in LP&R. 
No info for the amounts for self-employed benefits were given for either data source.